### PR TITLE
feat: add User-Agent to requests

### DIFF
--- a/GraphQLTester.py
+++ b/GraphQLTester.py
@@ -122,7 +122,10 @@ class GraphQLTester(object):
 
     def runTestQuery(self, url, query, params):
         """Run the test query and return the server's response."""
-        r = requests.post(url, data={'query': query, 'variables': params}, timeout=120)
+        data = {'query': query, 'variables': params}
+        headers = {'User-Agent': 'GraphQLTester/1.0'}
+
+        r = requests.post(url, data=data, headers=headers, timeout=120)
 
         # convert to json and then back into text rule out formatting differences
         try:


### PR DESCRIPTION
Jane was having issues following log traffic as there are more than one python requests script adding traffic to GraphQL now a days. It’s nice to be able to filter out the traffic coming from this client.